### PR TITLE
Use `@deprecated` info when building OpenAPI description

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/DeprecatedTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/DeprecatedTrait.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -70,6 +71,17 @@ public final class DeprecatedTrait extends AbstractTrait implements ToSmithyBuil
      */
     public Optional<String> getMessage() {
         return Optional.ofNullable(message);
+    }
+
+    public String getDeprecatedDescription(ShapeType shapeType) {
+        String shapeTypeString = shapeType == ShapeType.OPERATION ? "operation" : "shape";
+        if (getSince().isEmpty()) {
+            return getMessage().orElse("This " + shapeTypeString + " is deprecated.");
+        } else if (getMessage().isEmpty()) {
+            return "This " + shapeTypeString + " is deprecated since " + getSince().get();
+        } else {
+            return "This " + shapeTypeString + " is deprecated since " + getSince().get() + ": " + getMessage().get();
+        }
     }
 
     @Override

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/DeprecatedTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/DeprecatedTraitTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.SourceException;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
 
 public class DeprecatedTraitTest {
     @Test
@@ -47,5 +48,30 @@ public class DeprecatedTraitTest {
             TraitFactory provider = TraitFactory.createServiceFactory();
             provider.createTrait(ShapeId.from("smithy.api#deprecated"), ShapeId.from("ns.qux#foo"), Node.from("abc"));
         });
+    }
+
+    @Test
+    public void returnDefaultDescription() {
+        DeprecatedTrait deprecatedTrait = DeprecatedTrait.builder().build();
+        assertThat(deprecatedTrait.getDeprecatedDescription(ShapeType.OPERATION), equalTo("This operation is deprecated."));
+        assertThat(deprecatedTrait.getDeprecatedDescription(ShapeType.STRING), equalTo("This shape is deprecated."));
+    }
+
+    @Test
+    public void returnDescriptionWhenMessageSet() {
+        DeprecatedTrait deprecatedTrait = DeprecatedTrait.builder().message("Use X shape instead.").build();
+        assertThat(deprecatedTrait.getDeprecatedDescription(ShapeType.STRING), equalTo("Use X shape instead."));
+    }
+
+    @Test
+    public void returnDescriptionWhenSinceSet() {
+        DeprecatedTrait deprecatedTrait = DeprecatedTrait.builder().since("2020-01-01").build();
+        assertThat(deprecatedTrait.getDeprecatedDescription(ShapeType.STRING), equalTo("This shape is deprecated since 2020-01-01"));
+    }
+
+    @Test
+    public void returnDescriptionWhenBothSinceAndMessageSet() {
+        DeprecatedTrait deprecatedTrait = DeprecatedTrait.builder().since("2020-01-01").message("Use X shape instead.").build();
+        assertThat(deprecatedTrait.getDeprecatedDescription(ShapeType.STRING), equalTo("This shape is deprecated since 2020-01-01: Use X shape instead."));
     }
 }


### PR DESCRIPTION

#### Background
The purpose of this PR is to include `@deprecated` info inside the description of the definition in OpenAPI.

Let me know if this is something that makes sense, or if the way the description is built needs adjustment

#### Testing

Added tests in a couple of places.